### PR TITLE
Update OJConnection.js

### DIFF
--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -66,7 +66,7 @@ OJConn.prototype.execute = function(dbRequest, req, res, next) {
     var callParams = getCallParams(dbRequest, req);
     var callString = getCallString(dbRequest);
     //we do not want to log debug information for request params on the debugMaskList credit card numbers etc....
-    var logParams =  getCallParams(dbRequest, req,'Y');
+    var logParams =  getCallParams(dbRequest, req,true);
     req.execID = self.stats.totalExec++;
     debug('{%s} execute() id:%s CallString:%s | CallParams:%s', self.name, req.execID, callString, JSON.stringify(logParams));
     if (!self.connection || !self.connection.isConnected()) {
@@ -274,7 +274,7 @@ function getCallParams(dbRequest, req,useDebugMaskList) {
         } else {
             inputs=JSON.parse(JSON.stringify(req[dbRequest.request]));
         }
-        if (typeof dbRequest.debugMaskList !='undefined' && useDebugMaskList==='Y'){
+        if (typeof dbRequest.debugMaskList !='undefined' && useDebugMaskList){
             for (var x=0;x< dbRequest.debugMaskList.length;x++){
                 checkDebugMaskList(inputs, dbRequest.debugMaskList[x]);
             }

--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -65,8 +65,10 @@ OJConn.prototype.execute = function(dbRequest, req, res, next) {
     var self = this;
     var callParams = getCallParams(dbRequest, req);
     var callString = getCallString(dbRequest);
+    //we do not want to log debug information for request params on the debugMaskList credit card numbers etc....
+    var logParams =  getCallParams(dbRequest, req,'Y');
     req.execID = self.stats.totalExec++;
-    debug('{%s} execute() id:%s CallString:%s | CallParams:%s', self.name, req.execID, callString, JSON.stringify(callParams));
+    debug('{%s} execute() id:%s CallString:%s | CallParams:%s', self.name, req.execID, callString, JSON.stringify(logParams));
     if (!self.connection || !self.connection.isConnected()) {
         return next(new Error('Connection is bad'));
     }
@@ -147,7 +149,9 @@ OJConn.prototype.processData = function(results, dbRequest, req, res, next) {
         debug('{%s} Database Error:%s', JSON.stringify(data));
         self.close();
         if (dbRequest.noRespond) {
-            return next(new Error("Database not OK"));
+            var err = new Error("Database not OK");
+            err.data=data;
+            return next(err);
         } else {
             res.status(503).send({
                 status: 'Error',
@@ -245,15 +249,37 @@ function getCallString(dbRequest) {
     return callString;
 }
 
-function getCallParams(dbRequest, req) {
+function checkDebugMaskList(obj, propStr) {
+    var parts = propStr.split(".");
+    var cur = obj;
+    for (var i=0; i<parts.length; i++) {
+        if (!cur[parts[i]])
+            return false;
+        if (typeof cur[parts[i]] =='string'){
+            cur[parts[i]]= cur[parts[i]].replace(/[/a-z,A-Z,0-9]/gi,'*');
+        }
+        cur = cur[parts[i]];
+    }
+    return true;
+}
+
+
+function getCallParams(dbRequest, req,useDebugMaskList) {
     var callParams = [];
     if (dbRequest.inputs || dbRequest.request) {
+        var inputs;
         var paramString;
         if (dbRequest.inputs) {
-            paramString = JSON.stringify(dbRequest.inputs);
+            inputs=JSON.parse(JSON.stringify(dbRequest.inputs));
         } else {
-            paramString = JSON.stringify(req[dbRequest.request]);
+            inputs=JSON.parse(JSON.stringify(req[dbRequest.request]));
         }
+        if (typeof dbRequest.debugMaskList !='undefined' && useDebugMaskList==='Y'){
+            for (var x=0;x< dbRequest.debugMaskList.length;x++){
+                checkDebugMaskList(inputs, dbRequest.debugMaskList[x]);
+            }
+        }
+        paramString = JSON.stringify(inputs);
         callParams.push(paramString);
     }
     if (dbRequest.output) {


### PR DESCRIPTION
Change to allow a debugMaskList to mask any sensitive data as specified on a procedure call.

List is specified in request as array of object properties that should be masked when OJ debug is used.
var newPolCall = {
  procedure: "database.package.procedure",
  request: "allParams",
  output: true,
  noRespond: true,
  debugMaskList:["creditCard.cardNumber","creditCard.expDate","creditCard.cvn"]
};

A change for noRespond procedures to pass back error stack from database to error handler.
