### PR TITLE
Update OJConnection.js

### DIFF
--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -256,7 +256,7 @@ function checkDebugMaskList(obj, propStr) {
         if (!cur[parts[i]])
             return false;
         if (typeof cur[parts[i]] =='string'){
-            cur[parts[i]]= cur[parts[i]].replace(/[/a-z,A-Z,0-9]/gi,'*');
+            cur[parts[i]]= '***';
         }
         cur = cur[parts[i]];
     }


### PR DESCRIPTION
Change to function checkDebugMaskList. Instead of masking each character of sensitive data set data to constant value  '***', so its length cannot be determined.
