### PR TITLE
Update OJConnection.js

### DIFF
--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -87,8 +87,15 @@ OJConn.prototype.execute = function(dbRequest, req, res, next) {
             debug("{%s} Oracle Error(1):%s", err);
             return self.oracleError(err, dbRequest, res, next);
         } else if (results && results.returnParam) {
-            debug("{%s} Oracle returned a result", self.name);
+           debug("{%s} Oracle returned a result", self.name);
+            if (dbRequest.outputType==='BLOB'){
+             debug('BLOB Output Type');
+             //put blob into local data to be processed
+             res.locals.data=results.returnParam;
+             return next();
+            }else{
             return self.processData(results, dbRequest, req, res, next);
+            }
         }
         debug("{%s} Oracle no results from database: dbRequest.output%s", self.name, dbRequest.output);
         return self.noData(dbRequest, res, next);
@@ -287,8 +294,13 @@ function getCallParams(dbRequest, req,useDebugMaskList) {
         }
     }
     if (dbRequest.output) {
-        var out = new oracle.OutParam(oracle.OCCICLOB);
-        callParams.push(out);
+        // Check if output type is BLOB
+        if (dbRequest.outputType==='BLOB'){
+            var out = new oracle.OutParam(oracle.OCCIBLOB);
+        }else{
+             var out = new oracle.OutParam(oracle.OCCICLOB);
+        }
+            callParams.push(out);
     }
     return callParams;
 }


### PR DESCRIPTION
Changes to allow the processing of BLOB data types from Oracle database. If BLOB output type is specified than this data is stored in res.locals.data. The calling node service can then access and process this binary data.
