### PR TITLE
Use callback to handle errors

### DIFF
--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -59,7 +59,6 @@ OJConn.prototype.execute = function(dbRequest, inputData, callback) {
             debug("Oracle Error(1):%s", err);
             return callback(err);
         } else if (results && results.outBinds && results.outBinds[0]) {
-            debug("Oracle returned a result id:%s", self.connid);
             var lob = results.outBinds[0];
             return processLOB(lob, dbRequest, callback);
         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,18 +65,21 @@ OJ.prototype.getConnection = function(callback){
     self.connectionPool.getConnection(function(err, conn) {
         if (err) {
             debug('getConnection() Error:%s', err.toString());
-            throw new Error ('Unable to obtain a connection');
+            callback(null);
         }
         return callback(OJConn(self.connId++, conn));
     })
 };
 
 // Ensures the express req object has a connection set.
-function setExpressConnection(self, req, callback){
+function setExpressConnection(self, req, next, callback){
     if (req && req.ojconn) {
         return callback();
     }
     self.getConnection(function(conn) {
+        if(!conn){
+            next(new Error ('Unable to obtain a connection'));
+        }
         req.ojconn = conn;
         return callback();
     })
@@ -109,7 +112,7 @@ OJ.prototype.execute = function(dbRequest) {
         debug('OJ execute()');
         var inputData = dbRequest.inputs || (dbRequest.request ? req[dbRequest.request] : null);
         inputData = inputData && JSON.parse(JSON.stringify(inputData));
-        setExpressConnection(self, req, function() {
+        setExpressConnection(self, req, next, function() {
             req.ojconn.execute(dbRequest, inputData, function (err, data) {
                 req.ojconn.release();
                 req.ojconn = undefined;
@@ -136,7 +139,7 @@ OJ.prototype.test = function() {
     var self = this;
     return function(req, res, next) {
         debug('OJ test()');
-        setExpressConnection(self, req, function() {
+        setExpressConnection(self, req, next, function() {
             req.ojconn.test(function (err) {
                 if (err) {
                     req.ojconn.release();
@@ -151,9 +154,7 @@ OJ.prototype.test = function() {
 OJ.prototype.connect = function() {
     var self = this;
     return function(req, res, next) {
-        setExpressConnection(self, req, function() {
-            next();
-        });
+        setExpressConnection(self, req, next, next);
     }
 };
 
@@ -175,7 +176,7 @@ OJ.prototype.doExecsafe = function(dbRequest, callback) {
     var inputData =JSON.parse(JSON.stringify(dbRequest.inputs));
     self.getConnection(function(conn) {
         if(!conn) {
-            throw new Error("Unable to get a Connection")
+            return callback(new Error("Unable to get a Connection"));
         }
         function handleResult (err, data) {
             conn.release();
@@ -186,7 +187,7 @@ OJ.prototype.doExecsafe = function(dbRequest, callback) {
                 conn.release();
                 return self.getConnection(function(conn) {
                     if(!conn) {
-                        throw new Error("Unable to get a Connection")
+                        return callback(new Error("Unable to get a Connection"));
                     }
                     return conn.execute(dbRequest, inputData, handleResult);
                 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {


### PR DESCRIPTION
The Throw of Error when connection cannot be retrieved could hang the
Node/ Express process. Use the callback instead to handle this
gracefully.
