### PR TITLE
Return on error conditions to prevent further errors executing success code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ OJ.prototype.getConnection = function(callback){
     self.connectionPool.getConnection(function(err, conn) {
         if (err) {
             logInfo('getConnection() Error:%s', err.toString());
-            callback(null);
+            return callback(null);
         }
         conn.clientId = self.clientId;
         return callback(OJConn(self.connId++, conn));
@@ -93,7 +93,7 @@ function setExpressConnection(self, req, next, callback){
     }
     self.getConnection(function(conn) {
         if(!conn){
-            next(new Error ('Unable to obtain a connection'));
+            return next(new Error ('Unable to obtain a connection'));
         }
         req.ojconn = conn;
         return callback();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {


### PR DESCRIPTION
Not returning after error handling was leading to TypeError when executing the success block as conn was undefined.