### PR TITLE
Allow the connection pool to be restarted on connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ query
              Output will be set to res.locals.data
 `outputCount` The number of output Cursors to expect. Default 1.
 `numRows` number of rows to prefetch when processing queries/cursors.
+`databaseConnectionErrors` an array of Oracle connection errors codes that will cause the current connection pool to be shutdown, a new one started and the requested query/proc to be reprocessed.
+                           example value would be ["ORA-04068","ORA-06508","ORA-04061","ORA-03135"].
 
 
 # Examples:
@@ -71,6 +73,9 @@ app.get('/pricesafe',oj.execsafe(priceCall));
 ## Release History
 |Version|Date|Description|
 |:--:|:--:|:--| 
+|v2.1.3|2017-03-06|Added support to restart the connection pool on certain connection errors|
+|v2.1.2|2017-01-24|Fixed errors being raised because error handlign code was not returning from function|
+|v2.1.1|2016-10-19|Improved Error reporting|
 |v2.1.0|2016-10-04|Added handling of CURSORS and ResultSets from queries|
 |v2.0.2|2016-08-04|support the autoCommit property|
 |v2.0.1|2016-03-01|uses callback to handle errors|

--- a/README.md
+++ b/README.md
@@ -12,32 +12,32 @@ Requires the node `oracle` driver module.
   npm install oracle-json
 ```
 # Options:
-`database` connection parameters for the ''oracle'' node module.
-`databasePool` database pool settings which can be:
-    `poolTimeout` - time (s) that unused connections will be closed. Default 30.
-    `queueTimeout` - time (ms) to wait for a connection before returning an Error. Default 120000.
-    `poolMin` - The smallest number of connections the pool will shrink to - Default 0.
-    `poolMax` - The greatest number of connections the pool will grow to  - Default 1.
+* `database` - connection parameters for the ''oracle'' node module.
+* `databasePool` - database pool settings which can be:
+    * `poolTimeout` - time (s) that unused connections will be closed. Default 30.
+    * `queueTimeout` - time (ms) to wait for a connection before returning an Error. Default 120000.
+    * `poolMin` - The smallest number of connections the pool will shrink to - Default 0.
+    * `poolMax` - The greatest number of connections the pool will grow to  - Default 1.
 
 The following options are used on the call to execute a procedure;
 query
-`procedure` the name of the stored procedure to execute. If not specified a `query``must be specified instead
-`query` the query to execute. The response will be executed as a resultset and returned in res.locals.data.
+* `procedure` the name of the stored procedure to execute. If not specified a `query``must be specified instead
+* `query` the query to execute. The response will be executed as a resultset and returned in res.locals.data.
         You can reference the 'inputs'`or `request` values by name
         e.g `select * from table where id = :id` where `inputs` is {'id': 12}
-`noRespond` do not automatically respond to the client but save results of procedure as `res.locals.data`  
-`request` use the object named from express as the input to the procedure e.g. `request:"query"` will use `req.query`   
-`inputs` specifiy the input parameters explicitly in this object  
-`debugMaskList` array of object properties that should be masked in debug data e.g.  
+* `noRespond` do not automatically respond to the client but save results of procedure as `res.locals.data`
+* `request` use the object named from express as the input to the procedure e.g. `request:"query"` will use `req.query`
+* `inputs` specifiy the input parameters explicitly in this object
+* `debugMaskList` array of object properties that should be masked in debug data e.g.
   &nbsp;&nbsp;&nbsp;`debugMaskList:["card.cardNumber","card.expDate"]`  
-`outputType` BLOB: response will by read without any modification.
-             CURSOR: output will be processed as 1 or more (see ) CURSORS and converted to Arrays of JSON (using field names are object property names)
-             CLOB: or if not specified CLOB will be converted to JSON.
-             Output will be set to res.locals.data
-`outputCount` The number of output Cursors to expect. Default 1.
-`numRows` number of rows to prefetch when processing queries/cursors.
-`databaseConnectionErrors` an array of Oracle connection errors codes that will cause the current connection pool to be shutdown, a new one started and the requested query/proc to be reprocessed.
-                           example value would be ["ORA-04068","ORA-06508","ORA-04061","ORA-03135"].
+* `outputType`
+    * `BLOB`: response will by read without any modification.
+    * `CURSOR`: output will be processed as 1 or more (see ) CURSORS and converted to Arrays of JSON (using field names are object property names)
+    * `CLOB` (default): CLOB will be converted to JSON. Output will be set to res.locals.data
+* `outputCount` The number of output Cursors to expect. Default 1.
+* `numRows` number of rows to prefetch when processing queries/cursors.
+* `databaseConnectionErrors` an array of Oracle connection errors codes that will cause the current connection pool to be shutdown, a new one started and the requested query/proc to be reprocessed.
+                           e.g &nbsp;&nbsp;&nbsp; `databaseConnectionErrors`:["ORA-04068","ORA-06508","ORA-04061","ORA-03135"].
 
 
 # Examples:

--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -6,10 +6,11 @@ var oracle = require('oracledb'),
 
 module.exports = OJConn;
 
-function OJConn(connId, connection) {
-    if (!(this instanceof OJConn)) return new OJConn(connId, connection);
+function OJConn(connId, connection, connectionErrors) {
+    if (!(this instanceof OJConn)) return new OJConn(connId, connection, connectionErrors);
     this.connection = connection;
     this.connId = connId;
+    this.connectionErrors = connectionErrors;
     this.lastExecTime;
     this.lastExecProcName;
 }
@@ -26,6 +27,15 @@ OJConn.prototype.release = function(callback){
         return callback && callback();
     })
 };
+
+function connectionError(message, connectionErrors){
+    for (i in connectionErrors) {
+        if (message.indexOf(connectionErrors[i]) >= 0) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /*  Execute a procedure which has one of the following signatures;
 1.JSON in and JSON out
@@ -61,13 +71,17 @@ OJConn.prototype.execute = function(dbRequest, inputData, callback) {
         self.lastExecProcName = dbRequest.query ? 'SQL_QUERY' : dbRequest.procedure.split(/[.]+/).pop();
         logInfo('[%sms] %s id:%s handle_result Oracle call returned', self.lastExecTime, self.lastExecProcName, self.connId);
         if (err) {
+            if(connectionError(err.message, self.connectionErrors)){
+                err.connectionError = true;
+                return callback(err);
+            }
             logError("Oracle Error(1):%s", err);
             return callback(err);
         } else if (results && results.outBinds && results.outBinds.length > 0) {
-            return processResults(results.outBinds, dbRequest, callback);
+            return processResults(results.outBinds, dbRequest, self.connectionErrors, callback);
         } else if(results && results.resultSet){
             // processResults expects an Array for processing Cursors/ResultSets
-            return processResults([results.resultSet], dbRequest, callback);
+            return processResults([results.resultSet], dbRequest, self.connectionErrors, callback);
         }
         else if (dbRequest.output){
             logError("Oracle id:%s no results from database", results);
@@ -114,7 +128,7 @@ function fetchRowsFromRS(id, resultSet, numRows, callback, results){
       });
 }
 
-function processResults (output, dbRequest, callback){
+function processResults (output, dbRequest, connectionErrors, callback){
     if (dbRequest.outputType==='CURSOR' || dbRequest.query){
         var startFetch = new Date();
         var results = {};
@@ -125,8 +139,13 @@ function processResults (output, dbRequest, callback){
                     return callback(err);
                 }
                 if (rows.length === 1 && rows[0].status && rows[0].status.toUpperCase() == 'ERROR') {
-                    logError('Database Error:%s', JSON.stringify(rows[0]));
-                    return callback(new Error("Database not OK"));
+                    var message = JSON.stringify(rows[0])
+                    logError('Database Error:%s', message);
+                    var err = new Error("Database not OK");
+                    if(connectionError(message, connectionErrors)) {
+                        err.connectionError = true;
+                    }
+                    return callback(err);
                 }
                 logInfo('rs[%d] %d rows fetched - [%sms]', index, rows.length, new Date() - startFetch);
 
@@ -150,21 +169,21 @@ function processResults (output, dbRequest, callback){
         output.on('error', function(err) { callback(err); });
         output.on('data', function (part) { resultData = Buffer.concat([resultData, part]); });
         output.on('close', function () {
-            return processData(resultData, dbRequest, callback);
+            return processData(resultData, dbRequest, connectionErrors, callback);
         });
     } else {
         output.setEncoding('utf8');
         var resultData = '';
         output.on('error', function(err) { callback(err); });
         output.on('close', function () {
-            return processData(resultData, dbRequest, callback);
+            return processData(resultData, dbRequest, connectionErrors, callback);
         });
 
         output.on('data', function (part) { resultData += part; });
     }
 }
 
-function processData (results, dbRequest, callback) {
+function processData (results, dbRequest, connectionErrors, callback) {
     if(dbRequest.outputType === 'BLOB'){
         return callback(null, results);
     }
@@ -178,8 +197,13 @@ function processData (results, dbRequest, callback) {
     }
 
     if (data.status && data.status.toUpperCase() == 'ERROR') {
-        logError('Database Error:%s', JSON.stringify(data));
-        return callback(new Error("Database not OK"));
+        var message = JSON.stringify(data);
+        var err = new Error("Database not OK");
+        if(connectionError(message, connectionErrors)) {
+            err.connectionError = true;
+        }
+        logError('Database Error:%s', message);
+        return callback(err);
     }
 
     return callback(null, data);

--- a/lib/OJConnection.js
+++ b/lib/OJConnection.js
@@ -61,8 +61,7 @@ OJConn.prototype.execute = function(dbRequest, inputData, callback) {
     //we do not want to log debug information for request params on the debugMaskList credit card numbers etc....
     var logParams =  getCallParams(dbRequest, inputData,true);
     var options = getCallOptions(dbRequest);
-
-    logInfo('execute() id:%s CallString:%s | CallParams:%s', self.connId, callString, JSON.stringify(logParams));
+    logInfo('execute() id:%s CallString:%s | CallParams: %s ', self.connId, callString, logParams);
 
     var startExec = new Date();
     self.connection.execute(callString, callParams, options, handle_result);

--- a/lib/index.js
+++ b/lib/index.js
@@ -231,7 +231,7 @@ OJ.prototype.execsafe = function(dbRequest) {
 
 OJ.prototype.doExecsafe = function(dbRequest, callback) {
     var self = this;
-    var inputData =JSON.parse(JSON.stringify(dbRequest.inputs));
+    var inputData = dbRequest.inputs && JSON.parse(JSON.stringify(dbRequest.inputs));
     self.getConnection(function(conn) {
         if(!conn) {
             return callback(new Error("Unable to get a Connection"));

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,27 +40,60 @@ function OJ(options, callback) {
         dbSettings.poolMin = dbSettings.poolMax - 1;
         logInfo('poolMin invalid - defaulting to %d',  dbSettings.poolMin);
     }
-    var self = this;
-    oracle.createPool(dbSettings, function (err, pool) {
-        if (err) {
-            debug("failed to create connection pool on startup, exiting process", err, dbSettings);
-            process.exit(1);
-        }
-        logInfo('Pool Created Successfully');
-        self.connectionPool = pool;
+    this.poolSettings = dbSettings;
+    this.connectionErrors = options.databaseConnectionErrors || [];
+    this.createPool(callback);
+}
 
-        self.getConnection(function (conn) {
-            conn.test(function (err) {
-                if (err) {
-                    logError('testConnection() Error:%s', err.toString());
-                    process.exit(1);
-                }
-                conn.release();
-                callback();
-            });
+OJ.prototype.createPool = function(callback){
+  var self = this;
+  oracle.createPool(this.poolSettings, function (err, pool) {
+    if (err) {
+        debug("failed to create connection pool on startup, exiting process", err, dbSettings);
+        process.exit(1);
+    }
+    logInfo('Pool Created Successfully');
+    self.connectionPool = pool;
+
+    self.getConnection(function (conn) {
+        conn.test(function (err) {
+            if (err) {
+                logError('testConnection() Error:%s', err.toString());
+                process.exit(1);
+            }
+            conn.release();
+            callback();
         });
     });
+  });
 }
+
+
+OJ.prototype.refreshPool = function(callback){
+
+  if(this.connectionPool){
+    var pool = this.connectionPool;
+    this.connectionPool = null;
+
+    function handleTermination(err){
+      // The curent connection may not have been released by the time we try to terminate teh pool.
+      // There could also be other connections in use.
+      if(err) {
+        logError(err.message);
+        if (err.message.indexOf('ORA-24422') >= 0) {
+          return pool.terminate(handleTermination);
+        }
+        return;
+      }
+      logInfo('pool terminated');
+  }
+    pool.terminate(handleTermination);
+    return this.createPool(callback);
+  }
+  return callback();
+
+};
+
 
 
 OJ.prototype.getConnection = function(callback){
@@ -76,7 +109,7 @@ OJ.prototype.getConnection = function(callback){
             return callback(null);
         }
         conn.clientId = self.clientId;
-        return callback(OJConn(self.connId++, conn));
+        return callback(OJConn(self.connId++, conn, self.connectionErrors));
     })
 };
 
@@ -133,7 +166,15 @@ OJ.prototype.execute = function(dbRequest) {
                 req.ojconn.release();
                 req.ojconn = undefined;
                 if (err) {
-                    logError(err.message);
+                    if(err.connectionError && !(req.errCount > 0)){
+                      req.errCount = (req.errCount || 0) + 1;
+                      logError('Connection Error. Restarting Pool');
+
+                      return self.refreshPool(function () {
+                        return self.execute(dbRequest)(req, res, next);
+                      });
+                    }
+
                     return sendError(dbRequest.noRespond, res, next);
                 }
                 if (!data) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {


### PR DESCRIPTION
Especially relevant during Development. Restarts the connection pool and retries the request when we encounter errors such as :+1: 
existing state of package "..." has been invalidated
existing state of packages has been discarded
PL/SQL: could not find program unit being called

List is configurable (default is blank so is disabled by default) so we can add to the list if further error codes are encountered.
