### PR TITLE
Add a timeout to the retry of pool termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ app.get('/pricesafe',oj.execsafe(priceCall));
 ## Release History
 |Version|Date|Description|
 |:--:|:--:|:--| 
+|v2.1.4|2017-05-29|Fixed retry of Pool Termination where hundreds or thousands of failed requests could be made - there was not waiting before retry. |
 |v2.1.3|2017-03-06|Added support to restart the connection pool on certain connection errors|
 |v2.1.2|2017-01-24|Fixed errors being raised because error handlign code was not returning from function|
 |v2.1.1|2016-10-19|Improved Error reporting|

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,9 @@ OJ.prototype.refreshPool = function(callback){
       if(err) {
         logError(err.message);
         if (err.message.indexOf('ORA-24422') >= 0) {
-          return pool.terminate(handleTermination);
+          return setTimeout(function() {
+              pool.terminate(handleTermination)
+          }, 500);
         }
         return;
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {


### PR DESCRIPTION
prevents a cascade of failed attempts.