### PR TITLE
Upgrading oracle dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ app.get('/pricesafe',oj.execsafe(priceCall));
 ## Release History
 |Version|Date|Description|
 |:--:|:--:|:--|
+|v4.0.0|2019-08-12|Upgrade to oracledb v4
 |v3.1.0|2019-07-24|Upgrade module dependencies
 |v3.0.0|2018-02-19|Upgrade to version 3.0.x of oracledb and debug modules.
 |v2.1.6|2018-02-19|Use console.log when exiting process to ensure log messages are written.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ app.get('/pricesafe',oj.execsafe(priceCall));
 ## Release History
 |Version|Date|Description|
 |:--:|:--:|:--|
+|v3.1.0|2019-07-24|Upgrade module dependencies
 |v3.0.0|2018-02-19|Upgrade to version 3.0.x of oracledb and debug modules.
 |v2.1.6|2018-02-19|Use console.log when exiting process to ensure log messages are written.
 |v2.1.5|2018-01-29|Fix invalid reference in debug mesage.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {
@@ -23,11 +23,11 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "oracledb": "^3.1.0"
+    "oracledb": "^4.0.0"
   },
   "devDependencies": {},
   "engines": {
-    "node": ">=6"
+    "node": ">=8.16"
   },
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oracle-json",
   "description": "call oracle stored procedures using json input and output params",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "./lib",
   "homepage": "https://github.com/PhilCorcoran/oracle-json",
   "repository": {
@@ -22,8 +22,8 @@
     }
   ],
   "dependencies": {
-    "debug": "^4.1.0",
-    "oracledb": "^3.0.1"
+    "debug": "^4.1.1",
+    "oracledb": "^3.1.0"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
3.0.x -> 3.1.x simplifies npm install further by having pre-built binaries for various platforms and node version. No need for c++ compiler and installation works cross platform.